### PR TITLE
Fix incorrect provider error

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @jsf9k @mcdonnnj @cisagov/team-ois
+*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois

--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -1,0 +1,6 @@
+---
+version: "1"
+
+lineage:
+  skeleton:
+    remote-url: https://github.com/cisagov/skeleton-generic.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
 ---
 name: build
 
-on: [
-  push,
-  pull_request
-]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [apb]
 
 env:
   PIP_CACHE_DIR: ~/.cache/pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
             ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}"
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
       - name: Install Terraform-docs
-        run: go get github.com/segmentio/terraform-docs
+        run: GO111MODULE=on go get github.com/segmentio/terraform-docs
       - name: Find and initialize Terraform directories
         run: |
           for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2
         with:
-          go-version: '1.13.8'
+          go-version: '1.14.2'
       - name: Store installed Python version
         run: |
           echo "::set-env name=PY_VERSION::"\

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,6 +91,9 @@ repos:
       # https://github.com/hashicorp/terraform/pull/24896
       # is a proprosed fix to deal with `terraform validate` with proxy
       # providers (among other configurations).
+      # We have decided to disable the terraform_validate hook until the issues
+      # above have been resolved, which we hope will be with the release of
+      # Terraform 0.13.
       # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,19 @@ repos:
     rev: v1.29.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
+      # There are ongoing issues with how this command works. This issue
+      # documents the core issue:
+      # https://github.com/hashicorp/terraform/issues/21408
+      # We have seen issues primarily with proxy providers and Terraform code
+      # that uses remote state. The PR
+      # https://github.com/hashicorp/terraform/pull/24887
+      # has been approved and is part of the 0.13 release to resolve the issue
+      # with remote states.
+      # The PR
+      # https://github.com/hashicorp/terraform/pull/24896
+      # is a proprosed fix to deal with `terraform validate` with proxy
+      # providers (among other configurations).
+      # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:

--- a/providers.tf
+++ b/providers.tf
@@ -1,26 +1,16 @@
-# Default AWS region to use for the AWS providers.
-# This is needed to supply `terraform validate` with all of the required
-# parameters it needs to check the code.
-locals {
-  aws_region = "us-east-1"
-}
-
 # This is the default provider that is used to create resources inside
 # the Users account
 provider "aws" {
-  region = local.aws_region
 }
 
 # This is the provider that is used to create the role and policy that can
 # read Parameter Store parameters inside the Images Production account
 provider "aws" {
-  region = local.aws_region
-  alias  = "images-production"
+  alias = "images-production"
 }
 
 # This is the provider that is used to create the role and policy that can
 # read Parameter Store parameters inside the Images Staging account
 provider "aws" {
-  region = local.aws_region
-  alias  = "images-staging"
+  alias = "images-staging"
 }


### PR DESCRIPTION
## 🗣 Description

This pull request removes the dummy `region` arguments inside the `provider` blocks.  I also pulled in upstream changes.  The key commit is 5da4a4c.

## 💭 Motivation and Context

The dummy `region` arguments inside the `provider` blocks were causing the code in `examples/basic_usage` to fail to apply.  This is because providing the `region` argument actually results in an explicit provider (using the default profile) being created.  As stated in the penultimate paragraph in [this section](https://www.terraform.io/docs/configuration/modules.html#passing-providers-explicitly), "a proxy provider block is one that is either completely empty or that contains only the `alias` argument."

## 🧪 Testing

The code inside of `examples/basic_usage` successfully applies again.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
