### PR TITLE
Rework to add tags for role assumption and utilize ci-iam-user-tf-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,20 @@ module "example" {
   source = "github.com/cisagov/molecule-iam-user-tf-module"
 
   providers = {
-    aws                   = aws
-    aws.images-production = aws.images-production
-    aws.images-staging    = aws.images-staging
+    aws                                    = aws
+    aws.images-production-provisionaccount = aws.images-production-provisionaccount
+    aws.images-staging-provisionaccount    = aws.images-staging-provisionaccount
+    aws.images-production-ssm              = aws.images-production-ssm
+    aws.images-staging-ssm                 = aws.images-staging-ssm
   }
 
+  entity         = "my-repo"
   ssm_parameters = ["/example/parameter1", "/example/config/*"]
-  user_name      = "test-molecule-iam-user-tf-module"
+  user_name      = "test-my-repo"
 
   tags = {
     Team        = "VM Fusion - Development"
-    Application = "molecule-iam-user-tf-module testing"
+    Application = "my-repo testing"
   }
 }
 ```
@@ -36,17 +39,20 @@ module "example" {
   source = "github.com/cisagov/molecule-iam-user-tf-module"
 
   providers = {
-    aws                   = aws
-    aws.images-production = aws
-    aws.images-staging    = aws
+    aws                                    = aws
+    aws.images-production-provisionaccount = aws
+    aws.images-staging-provisionaccount    = aws
+    aws.images-production-ssm              = aws
+    aws.images-staging-ssm                 = aws
   }
 
+  entity         = "my-repo"
   ssm_parameters = ["/example/parameter1", "/example/config/*"]
-  user_name      = "test-molecule-iam-user-tf-module"
+  user_name      = "test-my-repo"
 
   tags = {
     Team        = "VM Fusion - Development"
-    Application = "molecule-iam-user-tf-module testing"
+    Application = "my-repo testing"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -78,20 +78,30 @@ In this case these errors are expected and can be safely ignored.
 
 * [Create an AWS IAM user capable of reading SSM Parameter Store parameters](https://github.com/cisagov/molecule-iam-user-tf-module/tree/develop/examples/basic_usage)
 
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| aws.images-production-provisionaccount | n/a |
+| aws.images-staging-provisionaccount | n/a |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-------:|:--------:|
-| ssm_parameters | The AWS SSM parameters that the IAM user needs to be able to read (e.g. ["/example/parameter1", "/example/config/*"]). | list(string) | | yes |
-| user_name | The name to associate with the AWS IAM user (e.g. test-molecule-iam-user-tf-module) | string | | yes |
-| tags | Tags to apply to all AWS resources created | map(string) | `{}` | no |
+|------|-------------|------|---------|:-----:|
+| entity | The name of the entity (usually a GitHub repository) being tested (e.g. molecule-iam-user-tf-module). | `string` | n/a | yes |
+| ssm_parameters | The AWS SSM parameters that the IAM user needs to be able to read (e.g. ["/example/parameter1", "/example/config/*"]). | `list(string)` | n/a | yes |
+| tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| access_key | The IAM access key associated with the IAM user created by this module. |
-| user | The IAM user created by this module. |
+| access_key | The IAM access key associated with the CI IAM user created by this module. |
+| production_role | The IAM role that the CI user can assume to read SSM parameters in the production account. |
+| staging_role | The IAM role that the CI user can assume to read SSM parameters in the staging account. |
+| user | The CI IAM user created by this module. |
 
 ## Notes ##
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ In this case these errors are expected and can be safely ignored.
 | Name | Version |
 |------|---------|
 | aws | n/a |
+| aws.images-production-ssm | n/a |
+| aws.images-staging-ssm | n/a |
 | aws.images-production-provisionaccount | n/a |
 | aws.images-staging-provisionaccount | n/a |
 

--- a/assume_parameterstorereadonly_role.tf
+++ b/assume_parameterstorereadonly_role.tf
@@ -17,6 +17,6 @@ data "aws_iam_policy_document" "assume_parameterstorereadonly_role_doc" {
 # ParameterStoreReadOnly role in the Images accounts (Production and Staging)
 resource "aws_iam_user_policy" "assume_parameterstorereadonly" {
   name   = "Images-Assume${module.parameterstorereadonly_role_production.role.name}"
-  user   = aws_iam_user.user.name
+  user   = module.ci_user.user.name
   policy = data.aws_iam_policy_document.assume_parameterstorereadonly_role_doc.json
 }

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -8,8 +8,24 @@ provider "aws" {
 # Images (Production) account
 provider "aws" {
   region  = "us-east-1"
+  profile = "cool-images-production-provisionaccount"
+  alias   = "images-production-provisionaccount"
+}
+
+# ProvisionParameterStoreReadRoles AWS provider for the
+# Images (Staging) account
+provider "aws" {
+  region  = "us-east-1"
+  profile = "cool-images-staging-provisionaccount"
+  alias   = "images-staging-provisionaccount"
+}
+
+# ProvisionParameterStoreReadRoles AWS provider for the
+# Images (Production) account
+provider "aws" {
+  region  = "us-east-1"
   profile = "cool-images-production-provisionparameterstorereadroles"
-  alias   = "images-production"
+  alias   = "images-production-ssm"
 }
 
 # ProvisionParameterStoreReadRoles AWS provider for the
@@ -17,20 +33,22 @@ provider "aws" {
 provider "aws" {
   region  = "us-east-1"
   profile = "cool-images-staging-provisionparameterstorereadroles"
-  alias   = "images-staging"
+  alias   = "images-staging-ssm"
 }
 
 module "iam_user" {
   source = "../.."
 
   providers = {
-    aws                   = aws
-    aws.images-production = aws.images-production
-    aws.images-staging    = aws.images-staging
+    aws                                    = aws
+    aws.images-production-provisionaccount = aws.images-production-provisionaccount
+    aws.images-staging-provisionaccount    = aws.images-staging-provisionaccount
+    aws.images-production-ssm              = aws.images-production-ssm
+    aws.images-staging-ssm                 = aws.images-staging-ssm
   }
 
+  entity         = "molecule-iam-user-tf-module"
   ssm_parameters = ["/example/parameter1", "/example/config/*"]
-  user_name      = "test-molecule-iam-user-tf-module"
 
   tags = {
     Team        = "VM Fusion - Development"

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -4,16 +4,14 @@ provider "aws" {
   profile = "cool-users-provisionaccount"
 }
 
-# ProvisionParameterStoreReadRoles AWS provider for the
-# Images (Production) account
+# ProvisionAccount AWS provider for the Images (Production) account
 provider "aws" {
   region  = "us-east-1"
   profile = "cool-images-production-provisionaccount"
   alias   = "images-production-provisionaccount"
 }
 
-# ProvisionParameterStoreReadRoles AWS provider for the
-# Images (Staging) account
+# ProvisionAccount AWS provider for the Images (Staging) account
 provider "aws" {
   region  = "us-east-1"
   profile = "cool-images-staging-provisionaccount"

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  user_name        = format("test-%s", var.entity)
+  role_name        = format("Test-%s", var.entity)
+  role_description = format("A role that can be assumed to allow for CI testing of %s via Molecule.", var.entity)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,20 @@
 output "access_key" {
-  value       = aws_iam_access_key.key
-  description = "The IAM access key associated with the IAM user created by this module."
+  value       = module.ci_user.access_key
+  description = "The IAM access key associated with the CI IAM user created by this module."
   sensitive   = true
 }
 
+output "production_role" {
+  value       = module.ci_user.production_role
+  description = "The IAM role that the CI user can assume to read SSM parameters in the production account."
+}
+
+output "staging_role" {
+  value       = module.ci_user.staging_role
+  description = "The IAM role that the CI user can assume to read SSM parameters in the staging account."
+}
+
 output "user" {
-  value       = aws_iam_user.user
-  description = "The IAM user created by this module."
+  value       = module.ci_user.user
+  description = "The CI IAM user created by this module."
 }

--- a/parameterstorereadonly_role.tf
+++ b/parameterstorereadonly_role.tf
@@ -12,12 +12,12 @@ module "parameterstorereadonly_role_production" {
   source = "github.com/cisagov/ssm-read-role-tf-module"
 
   providers = {
-    aws = aws.images-production
+    aws = aws.images-production-ssm
   }
 
   account_ids   = [data.aws_caller_identity.users.account_id]
-  entity_name   = var.user_name
-  iam_usernames = [var.user_name]
+  entity_name   = var.entity
+  iam_usernames = [module.ci_user.user.name]
   ssm_names     = var.ssm_parameters
 }
 
@@ -25,11 +25,11 @@ module "parameterstorereadonly_role_staging" {
   source = "github.com/cisagov/ssm-read-role-tf-module"
 
   providers = {
-    aws = aws.images-staging
+    aws = aws.images-staging-ssm
   }
 
   account_ids   = [data.aws_caller_identity.users.account_id]
-  entity_name   = var.user_name
-  iam_usernames = [var.user_name]
+  entity_name   = var.entity
+  iam_usernames = [module.ci_user.user.name]
   ssm_names     = var.ssm_parameters
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,16 +1,28 @@
 # This is the default provider that is used to create resources inside
-# the Users account
+# the Users account.
 provider "aws" {
+}
+
+# This is the provider that is used to create the role that can be
+# assumed to perform CI functions.
+provider "aws" {
+  alias = "images-production-provisionaccount"
+}
+
+# This is the provider that is used to create the role that can be
+# assumed to perform CI functions.
+provider "aws" {
+  alias = "images-staging-provisionaccount"
 }
 
 # This is the provider that is used to create the role and policy that can
 # read Parameter Store parameters inside the Images Production account
 provider "aws" {
-  alias = "images-production"
+  alias = "images-production-ssm"
 }
 
 # This is the provider that is used to create the role and policy that can
 # read Parameter Store parameters inside the Images Staging account
 provider "aws" {
-  alias = "images-staging"
+  alias = "images-staging-ssm"
 }

--- a/user.tf
+++ b/user.tf
@@ -1,14 +1,29 @@
-# ------------------------------------------------------------------------------
-# Create an IAM user and an associated access key
-# ------------------------------------------------------------------------------
+module "ci_user" {
+  source = "github.com/cisagov/ci-iam-user-tf-module"
 
-# The IAM user being created
-resource "aws_iam_user" "user" {
-  name = var.user_name
-  tags = var.tags
+  providers = {
+    aws            = aws
+    aws.production = aws.images-production-provisionaccount
+    aws.staging    = aws.images-staging-provisionaccount
+  }
+
+  role_description = local.role_description
+  role_name        = local.role_name
+  user_name        = local.user_name
+  tags             = var.tags
 }
 
-# The IAM access key for the user
-resource "aws_iam_access_key" "key" {
-  user = aws_iam_user.user.name
+# Attach the AWS SSM Parameter Store read role policies to the CI
+# production and staging roles
+resource "aws_iam_role_policy_attachment" "ssm_staging_attachment" {
+  provider = aws.images-staging-provisionaccount
+
+  policy_arn = module.parameterstorereadonly_role_staging.policy.arn
+  role       = module.ci_user.staging_role.name
+}
+resource "aws_iam_role_policy_attachment" "ssm_production_attachment" {
+  provider = aws.images-production-provisionaccount
+
+  policy_arn = module.parameterstorereadonly_role_production.policy.arn
+  role       = module.ci_user.production_role.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,13 +4,14 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
+variable "entity" {
+  type        = string
+  description = "The name of the entity (usually a GitHub repository) being tested (e.g. molecule-iam-user-tf-module)."
+}
+
 variable "ssm_parameters" {
   type        = list(string)
   description = "The AWS SSM parameters that the IAM user needs to be able to read (e.g. [\"/example/parameter1\", \"/example/config/*\"])."
-}
-
-variable "user_name" {
-  description = "The name to associate with the AWS IAM user (e.g. test-molecule-iam-user-tf-module)."
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## 🗣 Description

This pull request reworks this repo to add tags for role assumption and utilize [cisagov/ci-iam-user-tf-module](https://github.com/cisagov/ci-iam-user-tf-module).  Resolves #2.

## 💭 Motivation and Context

When I tried to use this repo to create a test user for [cisagov/ansible-role-kali](https://github.com/cisagov/ansible-role-kali) I realized that it was creating an SSM Parameter Store read role and an IAM user that was allowed to assume that role.  Furthermore, the role was not appropriately tagged to work with [`terraform-to-secrets`](https://github.com/cisagov/development-guide/blob/develop/project_setup/scripts/terraform-to-secrets).

What is really needed in our new multi-account setup is:
* A staging role and a production role that are allowed to do whatever is necessary to perform the testing in the appropriate account.
* An IAM user that can assume either of those roles.
* Policies that grant the necessary permissions and are attached to the staging and production roles.

To this end I created [cisagov/ci-iam-user-tf-module](https://github.com/cisagov/ci-iam-user-tf-module), which takes care of the first two bullets.  I then modified this repository to create the necessary SSM Parameter read policies and attach them to the appropriate roles.

## 🧪 Testing

I have successfully used these changes to create a test user in [cisagov/ansible-role-kali](https://github.com/cisagov/ansible-role-kali).

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
