### PR TITLE
Move to version 3.x of the AWS Terraform provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,15 @@ In this case these errors are expected and can be safely ignored.
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
-| aws.images-production-provisionaccount | ~> 2.0 |
-| aws.images-staging-provisionaccount | ~> 2.0 |
+| aws | ~> 3.0 |
+| aws.images-production-provisionaccount | ~> 3.0 |
+| aws.images-staging-provisionaccount | ~> 3.0 |
 
 ## Inputs ##
 

--- a/user.tf
+++ b/user.tf
@@ -1,5 +1,5 @@
 module "ci_user" {
-  source = "github.com/cisagov/ci-iam-user-tf-module?ref=improvement%2Fuse_tf_aws_3.x_provider"
+  source = "github.com/cisagov/ci-iam-user-tf-module"
 
   providers = {
     aws            = aws

--- a/user.tf
+++ b/user.tf
@@ -1,5 +1,5 @@
 module "ci_user" {
-  source = "github.com/cisagov/ci-iam-user-tf-module"
+  source = "github.com/cisagov/ci-iam-user-tf-module?ref=improvement%2Fuse_tf_aws_3.x_provider"
 
   providers = {
     aws            = aws

--- a/versions.tf
+++ b/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR moves this repo from using version 2 to version 3 of the [Terraform AWS provider](https://github.com/terraform-providers/terraform-provider-aws).

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
This repo is used by [`cisagov/skeleton-ansible-role-with-test-user`](https://github.com/cisagov/skeleton-ansible-role-with-test-user), which needs to be updated to 3.x, so this repo must be updated first.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
* I (temporarily) pointed this repo to the 3.x testing branch of [`cisagov/ci-iam-user-tf-module`](https://github.com/cisagov/ci-iam-user-tf-module) with https://github.com/cisagov/molecule-iam-user-tf-module/commit/35a496c9246699451f3e6e323c93a7bb327f06fe, then verified that I could successfully `terraform apply` and `terraform destroy` the [example code](https://github.com/cisagov/molecule-iam-user-tf-module/tree/develop/examples/basic_usage).  **Note that I will revert https://github.com/cisagov/molecule-iam-user-tf-module/commit/35a496c9246699451f3e6e323c93a7bb327f06fe after https://github.com/cisagov/ci-iam-user-tf-module/pull/14 is merged.**
* All pre-commit hooks pass.
## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
