### PR TITLE
Add the account type to the role names created for SSM Parameter Store access

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,29 +45,6 @@ module "example" {
 }
 ```
 
-#### Single Account Caveats ####
-
-This module is designed to create the role and associated policies in two
-accounts: staging and production. When run with a single account, you will
-receive errors when it tries to create the role and policies in the second
-internal provider as seen here:
-
-```console
-Error: Error creating IAM policy ParameterStoreReadOnly-test-molecule-iam-user-tf-module: EntityAlreadyExists: A policy called ParameterStoreReadOnly-test-molecule-iam-user-tf-module already exists. Duplicate names are not allowed.
-  status code: 409, request id: <removed>
-
-  on .terraform/modules/iam_user.parameterstorereadonly_role_production/policy.tf line 21, in resource "aws_iam_policy" "ssm_policy":
-  21: resource "aws_iam_policy" "ssm_policy" {
-
-Error: Error creating IAM Role ParameterStoreReadOnly-test-molecule-iam-user-tf-module: EntityAlreadyExists: Role with name ParameterStoreReadOnly-test-molecule-iam-user-tf-module already exists.
-  status code: 409, request id: <removed>
-
-  on .terraform/modules/iam_user.parameterstorereadonly_role_production/role.tf line 25, in resource "aws_iam_role" "ssm_role":
-  25: resource "aws_iam_role" "ssm_role" {
-```
-
-In this case these errors are expected and can be safely ignored.
-
 ## Examples ##
 
 - [Basic usage](https://github.com/cisagov/molecule-iam-user-tf-module/tree/develop/examples/basic_usage)

--- a/assume_parameterstorereadonly_role.tf
+++ b/assume_parameterstorereadonly_role.tf
@@ -4,7 +4,10 @@ data "aws_iam_policy_document" "assume_parameterstorereadonly_role_doc" {
   statement {
     effect = "Allow"
 
-    actions = ["sts:AssumeRole"]
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
 
     resources = [
       module.parameterstorereadonly_role_production.role.arn,

--- a/parameterstorereadonly_role.tf
+++ b/parameterstorereadonly_role.tf
@@ -18,6 +18,7 @@ module "parameterstorereadonly_role_production" {
   account_ids   = [data.aws_caller_identity.users.account_id]
   entity_name   = var.entity
   iam_usernames = [module.ci_user.user.name]
+  role_name     = "ParameterStoreReadOnly-%s-Production"
   ssm_names     = var.ssm_parameters
 }
 
@@ -31,5 +32,6 @@ module "parameterstorereadonly_role_staging" {
   account_ids   = [data.aws_caller_identity.users.account_id]
   entity_name   = var.entity
   iam_usernames = [module.ci_user.user.name]
+  role_name     = "ParameterStoreReadOnly-%s-Staging"
   ssm_names     = var.ssm_parameters
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds the `-Production` or `-Staging` suffix as appropriate to the roles created by the [cisagov/ssm-read-role-tf-module](https://github.com/cisagov/ssm-read-role-tf-module) module in this configuration. While here I also added the `sts:TagSession` permission to the role assumption document.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Right now when using a single account configuration (CyHy Ansible roles) there is a race to see which resources are created first as they share the same name. This fixes that issue and aligns this module's configuration with what is done in [cisagov/ci-iam-user-tf-module](https://github.com/cisagov/ci-iam-user-tf-module) (also used in this configuration) for [Production](https://github.com/cisagov/ci-iam-user-tf-module/blob/1576cd475dd7fe7f0a7550046a377489607e118d/roles.tf#L8) and [Staging](https://github.com/cisagov/ci-iam-user-tf-module/blob/1576cd475dd7fe7f0a7550046a377489607e118d/roles.tf#L19) roles.

We usually add the `sts:TagSession` permission wherever we allow the `sts:AssumeRole` permission so it was likely just missed in this configuration.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this branch in a CyHy Ansible role's Terraform configuration and confirmed that the apply completed successfully and there were no longer errors for already existing resources.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
