### PR TITLE
Make SSM parameters optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ module "example" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | entity | The name of the entity (usually a GitHub repository) being tested (e.g. molecule-iam-user-tf-module). | `string` | n/a | yes |
-| ssm\_parameters | The AWS SSM parameters that the IAM user needs to be able to read (e.g. ["/example/parameter1", "/example/config/*"]). | `list(string)` | n/a | yes |
+| ssm\_parameters | The AWS SSM parameters that the IAM user needs to be able to read (e.g. ["/example/parameter1", "/example/config/*"]). | `list(string)` | `[]` | no |
 
 ## Outputs ##
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ module "example" {
 | Name | Description |
 |------|-------------|
 | access\_key | The IAM access key associated with the CI IAM user created by this module. |
-| role | The IAM role that the CI user can assume to read SSM parameters. |
+| role | The IAM role that the CI user can assume to perform testing. |
 | user | The CI IAM user created by this module. |
 <!-- END_TF_DOCS -->
 

--- a/assume_parameterstorereadonly_role.tf
+++ b/assume_parameterstorereadonly_role.tf
@@ -1,6 +1,8 @@
 # IAM policy document that allows assumption of the ParameterStoreReadOnly
 # role in the Images account for this user
 data "aws_iam_policy_document" "assume_parameterstorereadonly_role_doc" {
+  count = local.ssm_needed
+
   statement {
     actions = [
       "sts:AssumeRole",
@@ -8,7 +10,7 @@ data "aws_iam_policy_document" "assume_parameterstorereadonly_role_doc" {
     ]
     effect = "Allow"
     resources = [
-      module.parameterstorereadonly_role.role.arn
+      module.parameterstorereadonly_role[0].role.arn
     ]
   }
 }
@@ -16,7 +18,9 @@ data "aws_iam_policy_document" "assume_parameterstorereadonly_role_doc" {
 # The IAM policy allowing this user to assume their custom
 # ParameterStoreReadOnly role in the Images account
 resource "aws_iam_user_policy" "assume_parameterstorereadonly" {
-  name   = "Images-Assume${module.parameterstorereadonly_role.role.name}"
-  policy = data.aws_iam_policy_document.assume_parameterstorereadonly_role_doc.json
+  count = local.ssm_needed
+
+  name   = "Images-Assume${module.parameterstorereadonly_role[0].role.name}"
+  policy = data.aws_iam_policy_document.assume_parameterstorereadonly_role_doc[0].json
   user   = module.ci_user.user.name
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,9 @@
 locals {
-  user_name        = format("test-%s", var.entity)
-  role_name        = format("Test-%s", var.entity)
   role_description = format("A role that can be assumed to allow for CI testing of %s via Molecule.", var.entity)
+  role_name        = format("Test-%s", var.entity)
+
+  # Determine if the CI user needs to be able to read SSM parameters
+  ssm_needed = length(var.ssm_parameters) > 0 ? 1 : 0
+
+  user_name = format("test-%s", var.entity)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "access_key" {
 }
 
 output "role" {
-  description = "The IAM role that the CI user can assume to read SSM parameters."
+  description = "The IAM role that the CI user can assume to perform testing."
   value       = module.ci_user.role
 }
 

--- a/parameterstorereadonly_role.tf
+++ b/parameterstorereadonly_role.tf
@@ -9,6 +9,7 @@ data "aws_caller_identity" "users" {
 }
 
 module "parameterstorereadonly_role" {
+  count  = local.ssm_needed
   source = "github.com/cisagov/ssm-read-role-tf-module"
 
   providers = {

--- a/user.tf
+++ b/user.tf
@@ -13,8 +13,9 @@ module "ci_user" {
 
 # Attach the AWS SSM Parameter Store read role policy to the CI role
 resource "aws_iam_role_policy_attachment" "ssm" {
+  count    = local.ssm_needed
   provider = aws.images-provisionaccount
 
-  policy_arn = module.parameterstorereadonly_role.policy.arn
+  policy_arn = module.parameterstorereadonly_role[0].policy.arn
   role       = module.ci_user.role.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,14 +10,15 @@ variable "entity" {
   type        = string
 }
 
-variable "ssm_parameters" {
-  description = "The AWS SSM parameters that the IAM user needs to be able to read (e.g. [\"/example/parameter1\", \"/example/config/*\"])."
-  nullable    = false
-  type        = list(string)
-}
-
 # ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
+
+variable "ssm_parameters" {
+  default     = []
+  description = "The AWS SSM parameters that the IAM user needs to be able to read (e.g. [\"/example/parameter1\", \"/example/config/*\"])."
+  nullable    = false
+  type        = list(string)
+}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes the `ssm_parameters` variable optional.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Previously, the list of parameters was required, but not all of our use cases had a need for to read SSM parameters, which forced us to put a dummy value in the list.  This PR allows us to avoid doing that.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this in a branch of `cisagov/skeleton-ansible-role-with-test-user` and confirmed that it worked as intended.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
