### PR TITLE
Add `moved` configuration blocks

### DIFF
--- a/assume_parameterstorereadonly_role.tf
+++ b/assume_parameterstorereadonly_role.tf
@@ -15,6 +15,11 @@ data "aws_iam_policy_document" "assume_parameterstorereadonly_role_doc" {
   }
 }
 
+moved {
+  from = data.aws_iam_policy_document.assume_parameterstorereadonly_role_doc
+  to   = data.aws_iam_policy_document.assume_parameterstorereadonly_role_doc[0]
+}
+
 # The IAM policy allowing this user to assume their custom
 # ParameterStoreReadOnly role in the Images account
 resource "aws_iam_user_policy" "assume_parameterstorereadonly" {
@@ -23,4 +28,9 @@ resource "aws_iam_user_policy" "assume_parameterstorereadonly" {
   name   = "Images-Assume${module.parameterstorereadonly_role[0].role.name}"
   policy = data.aws_iam_policy_document.assume_parameterstorereadonly_role_doc[0].json
   user   = module.ci_user.user.name
+}
+
+moved {
+  from = aws_iam_user_policy.assume_parameterstorereadonly
+  to   = aws_iam_user_policy.assume_parameterstorereadonly[0]
 }

--- a/parameterstorereadonly_role.tf
+++ b/parameterstorereadonly_role.tf
@@ -22,3 +22,8 @@ module "parameterstorereadonly_role" {
   role_name     = "ParameterStoreReadOnly-%s"
   ssm_names     = var.ssm_parameters
 }
+
+moved {
+  from = module.parameterstorereadonly_role
+  to   = module.parameterstorereadonly_role[0]
+}

--- a/user.tf
+++ b/user.tf
@@ -19,3 +19,8 @@ resource "aws_iam_role_policy_attachment" "ssm" {
   policy_arn = module.parameterstorereadonly_role[0].policy.arn
   role       = module.ci_user.role.name
 }
+
+moved {
+  from = aws_iam_role_policy_attachment.ssm
+  to   = aws_iam_role_policy_attachment.ssm[0]
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds `moved` configuration blocks for resources that were simply renamed in #62.

## 💭 Motivation and context ##

These will stop Terraform from destroying and recreating these resources if they are simply being renamed.

## 🧪 Testing ##

All automated tests pass.  I also pointed the Terraform code in cisagov/ansible-role-cyhy-archive#60 to this branch and verified that it simply moved the resources.  Without these changes that same Terraform code wanted to destroy and recreate the resources.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.